### PR TITLE
ASAA-151 - Update precompose to 1.6.0-beta02 and Compose to 1.6.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,15 @@
 [versions]
 agp = "8.2.2"
 androidx-window = "1.2.0"
-compose-plugin = "1.6.0"
+compose-plugin = "1.5.12"
 kotlin = "1.9.22"
 kt-lint-gradle = "11.6.1"
 navigation-compose = "2.7.7"
-precompose = "1.6.0-beta02"
+precompose = "1.5.11"
 
 compile-sdk = "34"
 min-sdk = "24"
-launchpad-compose = "0.0.3"
+launchpad-compose = "0.0.4"
 
 [libraries]
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation-compose" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
-agp = "8.2.1"
+agp = "8.2.2"
 androidx-window = "1.2.0"
-compose-plugin = "1.5.11"
-kotlin = "1.9.21"
+compose-plugin = "1.6.0"
+kotlin = "1.9.22"
 kt-lint-gradle = "11.6.1"
-navigation-compose = "2.7.6"
-precompose = "1.5.10"
+navigation-compose = "2.7.7"
+precompose = "1.6.0-beta02"
 
 compile-sdk = "34"
 min-sdk = "24"


### PR DESCRIPTION
also updated these below, but thats not related to this ticket.
gradle plugin to 8.2.2
kotlin to 1.9.22
android compose nav to 2.7.7
